### PR TITLE
Add support for other methods than GET and POST to ajax-lite.

### DIFF
--- a/src/taoensso/encore.cljx
+++ b/src/taoensso/encore.cljx
@@ -1667,7 +1667,8 @@
             (when-not (str/blank? s) s)))]
     (case method
       :get  [(if ?pstr (str uri "?" ?pstr) uri) nil]
-      :post [uri ?pstr])))
+      :post [uri ?pstr]
+      :put  [uri ?pstr])))
 
 #+cljs
 (defn ajax-lite
@@ -1695,7 +1696,7 @@
   (if-let [xhr (get-pooled-xhr!)]
     (try
       (let [timeout-ms (or (:timeout opts) timeout-ms) ; Deprecated opt
-            method*    (case method :get "GET" :post "POST")
+            method*    (case method :get "GET" :post "POST" :put "PUT")
             params     (map-keys name params)
             headers    (merge {"X-Requested-With" "XMLHTTPRequest"}
                          (map-keys name headers))


### PR DESCRIPTION
I am in the situation that I need to submit a PUT request with sente, and I noticed that it isn't supported. I think would make sense to support the usual suspects here in encore, so I am starting this PR both as a discussion on how to support the query parameters for the remaining request types, and to add support for PUT.

Request types that make sense to support:

- GET (__done__)
- POST (__done__)
- PUT (this PR)
- DELETE
- PATCH (maybe?)
- HEAD

There are a couple of questions here:

1. Do you want PATCH to be supported? I don't see why not, but maybe there is a reason.
2. How to handle query parameters for DELETE and PATCH? I assume it is the same as for POST and PUT, but I am not definitely sure.

What are your thoughts?