### PR TITLE
Fix call to 'str-join-once' from 'join-once'.

### DIFF
--- a/src/taoensso/encore.cljx
+++ b/src/taoensso/encore.cljx
@@ -2463,7 +2463,7 @@
 (defn round [n & [type nplaces]] (round* (or type :round) nplaces n))
 
 ;; & coll changed to coll:
-(defn join-once [sep & coll] (apply str-join-once coll))
+(defn join-once [sep & coll] (str-join-once sep coll))
 
 ;; Used by Carmine <= v2.7.0
 (defmacro repeatedly* [n & body] `(repeatedly-into* [] ~n ~@body))


### PR DESCRIPTION
The `sep` parameter was not passed and `str-join-once` was `apply`ed to `coll` resulting in a call like

```clojure
(join-once "/" "path-to" "file")
```

to succeed and produce:

```clojure
"fpath-toipath-tolpath-toe"
```

(`"path-to"` being used as the separator between each letter of `"file"`)