### PR TITLE
Make sure exponential backoff does not exceed Long range.

### DIFF
--- a/src/taoensso/encore.cljx
+++ b/src/taoensso/encore.cljx
@@ -799,7 +799,8 @@
 (defn exp-backoff "Returns binary exponential backoff value."
   [nattempt & [{:keys [factor] min' :min max' :max :or {factor 1000}}]]
   (let [binary-exp (double (Math/pow 2 (dec ^long nattempt)))
-        time       (* (+ binary-exp ^double (rand binary-exp)) 0.5 (double factor))]
+        time       (* (+ binary-exp ^double (rand binary-exp)) 0.5 (double factor))
+        time       (min Long/MAX_VALUE time)]
     (long (let [time (if min' (max (long min') (long time)) time)
                 time (if max' (min (long max') (long time)) time)]
             time))))


### PR DESCRIPTION
An exception is thrown when calling `exp-backoff` with higher `nattempt`, e.g.:

```clojure
(taoensso.encore/exp-backoff 64 {:max 10000})
;; IllegalArgumentException Value out of range for long: 7.864640105381429E21

(taoensso.encore/exp-backoff 1024 {:max 10000})
;; IllegalArgumentException Value out of range for long: Infinity
```

This fixes the issue by ensuring that the result, before applying `:min` and `:max`, does not exceed Long/MAX_VALUE.