### PR TITLE
fix invariant check to allow FormData as params

### DIFF
--- a/src/taoensso/encore.cljx
+++ b/src/taoensso/encore.cljx
@@ -2706,7 +2706,7 @@
               :else [uri (url-encode params)]))]
 
       (fn [uri method params]
-        (have? [:or nil? map?] params)
+        (have? [:or nil? map? js-form-data?] params)
         (case method
           :get  (url-encode      uri params)
           :post (adaptive-encode uri params)


### PR DESCRIPTION
Hey Peter,

This lets us use FormData as params in the ajax-lite function again.