### PR TITLE
Remove reflection warning caused by overloads introduced by Java 10

### DIFF
--- a/src/taoensso/encore.cljx
+++ b/src/taoensso/encore.cljx
@@ -2907,7 +2907,7 @@
   #+cljs [s]
   (when s
     #+clj  (-> (str s)
-               (java.net.URLEncoder/encode (or encoding "UTF-8"))
+               (java.net.URLEncoder/encode ^String (or encoding "UTF-8"))
                (str/replace "*" "%2A")
                (str/replace "+" "%2B"))
     #+cljs (-> (str s)
@@ -2920,7 +2920,7 @@
 (defn url-decode "Stolen from http://goo.gl/99NSR1"
   [s & [encoding]]
   (when s
-    #+clj  (java.net.URLDecoder/decode s (or encoding "UTF-8"))
+    #+clj  (java.net.URLDecoder/decode ^String s ^String (or encoding "UTF-8"))
     #+cljs (js/decodeURIComponent s)))
 
 (comment (url-decode (url-encode "Hello there~*+")))


### PR DESCRIPTION
Java 10 added an overload with a Charset as second argument for these
methods:

 java.net.URLEncoder.encode(java.lang.String, java.lang.String)
 java.net.URLEncoder.encode(java.lang.String, java.nio.charset.Charset)

 java.net.URLDecoder.decode(java.lang.String, java.lang.String)
 java.net.URLDecoder.decode(java.lang.String, java.nio.charset.Charset)

My change removes the reflection warning by casting both arguments to
String in the #+clj case trusting that clojure prefers the String
variant.

Please note the asymmetry in the implementation of url-encode which
calls str on the first argument and url-decode which does not.