### PR TITLE
Fix ISO8601 date/time pattern separator and time zone designator.

### DIFF
--- a/src/taoensso/encore.cljx
+++ b/src/taoensso/encore.cljx
@@ -2451,7 +2451,7 @@
     (fn [pattern locale timezone]
       (let [pattern
             (case pattern
-              :iso8601 "yyyy-MM-dd HH:mm:ss.SSSZ"
+              :iso8601 "yyyy-MM-dd'T'HH:mm:ss.SSSX"
               :rss2    "EEE, dd MMM yyyy HH:mm:ss z"
               pattern)
 


### PR DESCRIPTION
The ISO8601 separator is wrong. It should print timestamps like "2018-11-24T16:00:48.999Z" instead of "2018-11-24 16:00:48.999+0000" (for UTC).

Regarding [Timbre #155](https://github.com/ptaoussanis/timbre/issues/155) it deserves a fix.