### PR TITLE
goog.structs/Map is deprecated in Closure Library

### DIFF
--- a/src/taoensso/encore.cljx
+++ b/src/taoensso/encore.cljx
@@ -72,7 +72,6 @@
    [goog.net.XhrIo      :as gxhr]
    [goog.net.XhrIoPool  :as gxhr-pool]
    [goog.Uri.QueryData  :as gquery-data]
-   [goog.structs        :as gstructs]
    [goog.net.EventType]
    [goog.net.ErrorCode]
    [taoensso.truss :as truss])
@@ -2867,7 +2866,7 @@
           (fn url-encode
             ([params]
              (when (seq params)
-               (-> params clj->js gstructs/Map. gquery-data/createFromMap .toString)))
+               (-> params clj->js gquery-data/createFromMap .toString)))
 
             ([uri params]
              (let [qstr (url-encode params)


### PR DESCRIPTION
Resolves #47 

This PR removes usage of deprecated class `goog.structs/Map`. It's safe to use regular JavaScript object instead of `Map` since `goog.Uri.QueryData/createFromMap` takes a mapping from *string keys* to values in a form of either map or an object, see https://google.github.io/closure-library/api/goog.Uri.QueryData.html#QueryData.createFromMap