### PR TITLE
Add clj-kondo hooks

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["taoensso/encore"]}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ pom.xml*
 /checkouts/
 /logs/
 /docs/
+/.clj-kondo/.cache
 /doc/
 .idea/
 *.iml

--- a/resources/clj-kondo.exports/taoensso/encore/config.edn
+++ b/resources/clj-kondo.exports/taoensso/encore/config.edn
@@ -1,0 +1,1 @@
+{:hooks {:analyze-call {taoensso.encore/defalias taoensso.encore/defalias}}}

--- a/resources/clj-kondo.exports/taoensso/encore/taoensso/encore.clj
+++ b/resources/clj-kondo.exports/taoensso/encore/taoensso/encore.clj
@@ -1,0 +1,16 @@
+(ns taoensso.encore
+  (:require
+   [clj-kondo.hooks-api :as hooks]))
+
+(defn defalias [{:keys [node]}]
+  (let [[sym-raw src-raw] (rest (:children node))
+        src (if src-raw src-raw sym-raw)
+        sym (if src-raw
+              sym-raw
+              (symbol (name (hooks/sexpr src))))]
+    {:node (with-meta
+             (hooks/list-node
+               [(hooks/token-node 'def)
+                (hooks/token-node (hooks/sexpr sym))
+                (hooks/token-node (hooks/sexpr src))])
+             (meta src))}))


### PR DESCRIPTION
This should make clj-kondo understand the `defalias` custom macro and correctly lint it as an alias, this PR also add the hook config to resources classpath following [export feature](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#exporting-and-importing-configuration), this make clj-kondo understand this macro on any lib that uses encore for example `taoensso.timbre/spit-appender`, the user only needs to add to its clj-kondo config a `{:config-paths ["taoensso/encore"]}`.

Some examples of other libs that did the same: [midje](https://github.com/marick/Midje/tree/master/test-resources/clj-kondo.exports/marick/midje), [state-flow](https://github.com/nubank/state-flow/tree/master/resources/clj-kondo.exports/nubank/state-flow)