### PR TITLE
Avoid warnings in clojure 1.11

### DIFF
--- a/src/taoensso/encore.cljc
+++ b/src/taoensso/encore.cljc
@@ -36,7 +36,7 @@
     simple-symbol?  qualified-symbol?
     simple-keyword? qualified-keyword?
     format update-in merge merge-with
-    memoize])
+    memoize abs])
 
   #?(:clj
      (:require


### PR DESCRIPTION
Clojure 1.11 introduced the `abs` method

Without this change, we will see this warning line every time we load the library

```
WARNING: abs already refers to: #'clojure.core/abs in namespace: taoensso.encore, being replaced by: #'taoensso.encore/abs
```