### PR TITLE
Fix: rfirst-kv was not returning first matching element

### DIFF
--- a/src/taoensso/encore.cljc
+++ b/src/taoensso/encore.cljc
@@ -1069,8 +1069,8 @@
       ([      pred coll] (reduce                      (rf pred)  nil coll))
       ([xform pred coll] (transduce xform (completing (rf pred)) nil coll))))
 
-  (let [rf (fn [pred] (fn [acc  k v]  (when (pred k v) (reduced (get acc k) #_[k v]))))
-        tf (fn [pred] (fn [acc [k v]] (when (pred k v) (reduced (get acc k) #_[k v]))))]
+  (let [rf (fn [pred] (fn [acc  k v]  (when (pred k v) (reduced [k v]))))
+        tf (fn [pred] (fn [acc [k v]] (when (pred k v) (reduced [k v]))))]
     (defn rfirst-kv
         ([      pred coll] (reduce-kv                   (rf pred)  nil coll))
       #_([xform pred coll] (transduce xform (completing (tf pred)) nil coll))))
@@ -1087,6 +1087,8 @@
       #_([xform pred coll] (transduce xform (completing (tf pred)) true coll)))))
 
 (comment
+  (= (rfirst-kv (fn [k v] (number? v)) {:a :b :c 2}) [:c 2])
+
   (qb 1e4
     (some  #(when (string? %) %) [:a :b :c :d "boo"])
     (rsome #(when (string? %) %) [:a :b :c :d "boo"])

--- a/src/taoensso/encore.cljc
+++ b/src/taoensso/encore.cljc
@@ -2756,6 +2756,42 @@
   (get-substring "hello world" -8 2)
   (get-substring "hello world" 2 2))
 
+(defn
+  #?(:clj           case-insensitive-str=
+     :cljs ^boolean case-insensitive-str=)
+
+  "Returns true iff given strings are equal, ignoring case."
+  ;; Implementation detail:
+  ;; Compares normalized chars 1 by 1, so often faster than naive comparison
+  ;; of normalized strings.
+  [s1 s2]
+  #?(:clj (.equalsIgnoreCase ^String s1 ^String s2)
+     :cljs
+     (or
+       (identical? s1 s2)
+       (let [l1 (.-length s1)
+             l2 (.-length s2)]
+         (and
+           (== l1 l2)
+           ;; (= (str/lower-case s1) (str/lower-case s2))
+           ;; Still needs bench comparison:
+           (reduce-n
+             (fn [acc idx]
+               (let [c1 (.toLowerCase (.charAt s1 idx))
+                     c2 (.toLowerCase (.charAt s2 idx))]
+                 (if (= c1 c2) true (reduced false))))
+             true
+             0
+             l1))))))
+
+(comment
+  (qb 1e6
+    (do                 (= "-abcdefghijklmnop" "_abcdefghijklmnop"))
+    (case-insensitive-str= "-abcdefghijklmnop" "_abcdefghijklmnop")
+    (=
+      (str/lower-case "-abcdefghijklmnop")
+      (str/lower-case "_abcdefghijklmnop"))))
+
 #?(:clj
    (defn norm-str
      "Given a Unicode string, returns the normalized de/composed form.


### PR DESCRIPTION
Prior to [Add xform support to: rsome, rfirst, revery?](https://github.com/ptaoussanis/encore/commit/9226ea8d62c13ce84fdfe1c064a5cf6ab6c469c7#diff-97d1ee6e79f1ceb020e49665fd3aa43c41548d019842da7d63441e182869e649R1030) included in v3.22.0

```clojure
; Before 9226ea8d62c13ce84fdfe1c064a5cf6ab6c469c7
(rfirst-kv (fn [k v] (number? v)) {:a :b :c 2})
;=> [:c 2]

; After 9226ea8d62c13ce84fdfe1c064a5cf6ab6c469c7
(rfirst-kv (fn [k v] (number? v)) {:a :b :c 2})
;=> nil
```

After the commit, it returns `nil`, and continues to do so in the most recent version. This PR restores the previous behavior. 